### PR TITLE
ci: remove YAML anchor from Go workflow

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -6,14 +6,13 @@ on:
   pull_request:
     branches: ["main"]
 
-env: &env
-  DATABASE_URL: postgresql://admin:hunter2@postgres/project?sslmode=disable
-  REDIS_URL: redis://valkey:6379/0
-
 jobs:
   build:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    env:
+      DATABASE_URL: postgresql://admin:hunter2@postgres/project?sslmode=disable
+      REDIS_URL: redis://valkey:6379/0
 
     services:
       postgres:


### PR DESCRIPTION
#2 maintained a YAML anchor which is not allowed in GitHub actions.